### PR TITLE
rfkill: set encoding as NULL

### DIFF
--- a/plugins/rfkill/rfkill-glib.c
+++ b/plugins/rfkill/rfkill-glib.c
@@ -436,6 +436,7 @@ cc_rfkill_glib_open (CcRfkillGlib  *rfkill,
 
 	/* Setup monitoring */
 	rfkill->channel = g_io_channel_unix_new (fd);
+	g_io_channel_set_encoding (rfkill->channel, NULL, NULL);
 	rfkill->watch_id = g_io_add_watch (rfkill->channel,
 					   G_IO_IN | G_IO_HUP | G_IO_ERR,
 					   (GIOFunc) event_cb,


### PR DESCRIPTION
The default encoding for GIOChannel is UTF-8, but rfkill event is binary
data. If the value is invalid UTF-8, gsd-rfkill-manager will fail to
receive rkfill event.