### PR TITLE
Adding an embedded chassis_type to check during power off button press

### DIFF
--- a/plugins/media-keys/gsd-media-keys-manager.c
+++ b/plugins/media-keys/gsd-media-keys-manager.c
@@ -2224,8 +2224,9 @@ do_config_power_button_action (GsdMediaKeysManager *manager,
         if (priv->power_button_disabled)
                 return;
 
-        /* Always power off VMs when power off is pressed in the menus */
-        if (g_strcmp0 (priv->chassis_type, "vm") == 0) {
+        /* Always power off VMs or embedded when power off is pressed in the menus */
+        if ((g_strcmp0 (priv->chassis_type, "vm") == 0) ||
+            (g_strcmp0 (priv->chassis_type, "embedded") == 0)) {
                 power_action (manager, "PowerOff", !in_lock_screen);
                 return;
         }


### PR DESCRIPTION
A lot of times Linux devices are used as kiosks, multimedia centers or game devices. And the end user is expecting to press the power button and see the device powering off.

For this reason, I'm just adding a `embedded` chassis_type (valid type from [hostnamectl](https://www.freedesktop.org/software/systemd/man/hostnamectl.html)) that will allow the power off button to call power off immediately.

I'm using a chassis_type other than `vm` because probably we can use `vm` chassis_type for other checks in the future.

I'm not excluding it from the airplane button check (at `plugins/rfkill/gsd-rfkill-manager.c`), because it's useful just kill all the communication on this kind of devices.