### PR TITLE
Provide settings for suspend/hibernate key behavior

### DIFF
--- a/data/org.gnome.settings-daemon.plugins.power.gschema.xml.in
+++ b/data/org.gnome.settings-daemon.plugins.power.gschema.xml.in
@@ -36,6 +36,16 @@
       <summary>Enable the ALS sensor</summary>
       <description>If the ambient light sensor functionality is enabled.</description>
     </key>
+    <key name="hibernate-button-action" enum="org.gnome.settings-daemon.GsdPowerButtonActionType">
+      <default>'hibernate'</default>
+      <summary>Hibernate button action</summary>
+      <description>The action to take when the system hibernate button is pressed.</description>
+    </key>
+    <key name="suspend-button-action" enum="org.gnome.settings-daemon.GsdPowerButtonActionType">
+      <default>'suspend'</default>
+      <summary>Suspend button action</summary>
+      <description>The action to take when the system suspend button is pressed.</description>
+    </key>
     <key name="power-button-action" enum="org.gnome.settings-daemon.GsdPowerButtonActionType">
       <default>'suspend'</default>
       <summary>Power button action</summary>


### PR DESCRIPTION
Adds `suspend-button-action` and `hibernate-button-action` settings to go alongside the power-button-action setting.  This lets the user change the behavior of these buttons, or disable them if needed, again.

See https://askubuntu.com/questions/1103856/how-to-disable-sleep-suspend-hibernate-hp-keyboard-buttons-for-ubuntu-18-04/1232779 for some links to information on the importance of this.  Personally, my suspend button is right next to escape, and I use vim as an editor, so I am mashing escape all the time, and my hands shake from neurological issues, so I hit suspend by accident a lot, which is very frustrating in the middle of editing documents.